### PR TITLE
Ignore container files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,10 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# Container files
+singularity
+Dockerfile
+
 # Generator files
 gen/
 py.py


### PR DESCRIPTION
Ignore `Dockerfile` and `singularity` files created during container auto build.