### PR TITLE
Add `order` option

### DIFF
--- a/madlad/controls/launch.py
+++ b/madlad/controls/launch.py
@@ -16,7 +16,10 @@ def launchEvtGen(cfg : DictConfig, dir: str, logger) -> None:
     ecard = open(f"mg5_exec_card-{os.path.basename(dir)}","w")
     if cfg['run']['no-shower']:
         logger.info('Writing Gen card, without parton shower.')
-        ecard.write(f"launch {dir} -i\ngenerate_events -p")
+        if cfg['gen']['no-block_model']['order'].lower() == "lo":
+            ecard.write(f"launch {dir} -i\ngenerate_events")
+        else:
+            ecard.write(f"launch {dir} -i\ngenerate_events -p")
     else:
         logger.info('Writing Gen card.')
         ecard.write(f"launch {dir}")

--- a/processes/ttbar-allhad.yaml
+++ b/processes/ttbar-allhad.yaml
@@ -10,6 +10,7 @@ gen:
     model:          loop_sm-no_b_mass
     multiparticle:  ["p = g u c d s u~ c~ d~ s~ b b~", "j = g u c d s u~ c~ d~ s~ b b~"]
     proc:           "p p > t t~ [QCD]"
+    order:          "nlo"
     save_dir:       "Output"
 
   block_run:


### PR DESCRIPTION
Add option item `order`, use to enable MadLAD to distinguish LO generation from NLO. This commit also fix LO generation `no_shower` bug.