### PR TITLE
Change MadLAD base image to Ubuntu:20.04

### DIFF
--- a/examples/config_build.yaml
+++ b/examples/config_build.yaml
@@ -2,12 +2,12 @@ image:
   name:    "madlad-custom"
 
 build:
-  mg5:     "2.9.18" # MG5 version, (or path to a local installation)
-  pythia:  "8.301"
-  lhapdf:  "6.5.0"
+  mg5:     "3.5.6" # MG5 version, (or path to a local installation)
+  pythia:  "8.313"
+  lhapdf:  "6.5.5"
   fastjet: "3.4.0"
   delphes: "3.5.0"
 
 extra:
-  pdfs:   [260000, 260400, 303400]          # Additional pdf sets
+  pdfs:   [260000, 260400, 303400, 315000]  # Additional pdf sets
   models: ["2HDMtII_NLO", "HC_NLO_X0_UFO"]  # Additional models

--- a/madlad/container/Dockerfile
+++ b/madlad/container/Dockerfile
@@ -22,7 +22,7 @@ RUN apt install -y gfortran libpcre3-dev \
     libgl2ps-dev \
     liblzma-dev libxxhash-dev liblz4-dev libzstd-dev
 
-RUN apt install -y nano vim rsync wget unzip ghostscript \
+RUN apt install -y nano vim rsync wget unzip ghostscript bc \
     python3-pip python3-six
 
 # Link Python

--- a/madlad/container/Dockerfile
+++ b/madlad/container/Dockerfile
@@ -1,71 +1,48 @@
-FROM centos:centos7
+FROM ubuntu:focal
 
 # metainformation
-LABEL org.opencontainers.image.version = "3.0.0"
-LABEL org.opencontainers.image.authors = "Zihan Zhang"
-LABEL org.opencontainers.image.source = "https://zhangzi.web.cern.ch"
-LABEL org.opencontainers.image.base.name="docker.io/library/centos:centos7"
+LABEL org.opencontainers.image.version="4.0.0"
+LABEL org.opencontainers.image.authors="Zihan Zhang"
+LABEL org.opencontainers.image.source="https://zhangzi.web.cern.ch"
 
-RUN yum update -y && yum groupinstall "Development Tools" -y \
- && yum install -y zlib-devel bzip2-devel openssl-devel ncurses-devel sqlite-devel \
-    readline-devel tk-devel gdbm-devel db4-devel libpcap-devel xz-devel libXpm-devel \
-    libXext-devel wget which ghostscript
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/lib
 
-RUN yum install -y epel-release redhat-lsb-core gcc-gfortran pcre-devel \
-    mesa-libGL-devel mesa-libGLU-devel glew-devel ftgl-devel mysql-devel \
-    fftw-devel cfitsio-devel graphviz-devel libuuid-devel \
-    avahi-compat-libdns_sd-devel openldap-devel \
-    libxml2-devel gsl-devel readline-devel qt5-qtwebengine-devel \
-    R-devel R-Rcpp-devel R-RInside-devel
+RUN apt update -y && apt upgrade -y
 
-RUN cd /tmp \
- && wget https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3.tar.gz \
- && tar -zxf cmake-3.28.3.tar.gz && cd cmake-3.28.3 \
- && ./bootstrap && make && make install 
+RUN apt install -y binutils cmake dpkg-dev g++ gcc libssl-dev git libx11-dev \
+    libxext-dev libxft-dev libxpm-dev python3 libtbb-dev libgif-dev
+
+RUN apt install -y gfortran libpcre3-dev \
+    libglu1-mesa-dev libglew-dev libftgl-dev \
+    libfftw3-dev libcfitsio-dev libgraphviz-dev \
+    libavahi-compat-libdnssd-dev libldap2-dev \
+    python3-dev python3-numpy libxml2-dev libkrb5-dev \
+    libgsl-dev qtwebengine5-dev nlohmann-json3-dev libmysqlclient-dev \
+    libgl2ps-dev \
+    liblzma-dev libxxhash-dev liblz4-dev libzstd-dev
+
+RUN apt install -y nano vim rsync wget unzip ghostscript \
+    python3-pip python3-six
+
+# Link Python
+RUN ln -fs /usr/bin/python3 /usr/bin/python
 
 # Install ROOT
 RUN cd /tmp \
- && wget https://root.cern/download/root_v6.24.08.source.tar.gz \
- && tar -zxf root_v6.24.08.source.tar.gz && mkdir root_build && cd root_build \
- && cmake ../root-6.24.08 && cmake --build . -- install
-
-# Install Python=3.10
-RUN cd /tmp \
- && wget https://www.python.org/ftp/python/3.9.17/Python-3.9.17.tgz \
- && tar -zxf Python-3.9.17.tgz && cd Python-3.9.17 \
- && ./configure --enable-optimizations && make altinstall \
- && ln -fs /usr/local/bin/python3.9 /usr/bin/python3 \
- && ln -fs /usr/local/bin/pip3.9 /usr/bin/pip3 \
- && ln -fs /usr/local/bin/python3.9 /usr/bin/python \
- && ln -fs /usr/local/bin/pip3.9 /usr/bin/pip
+ && git clone --branch latest-stable --depth=1 https://github.com/root-project/root.git root_src \
+ && mkdir root_build && cd root_build \
+ && cmake ../root_src && cmake --build . -- install
 
 # Install HepMC2
 RUN cd /tmp \
- && wget http://hepmc.web.cern.ch/hepmc/releases/hepmc2.06.09.tgz \
- && tar -zxf hepmc2.06.09.tgz && cd hepmc2.06.09 \
- && ./configure --prefix=/usr/local --with-momentum=GEV --with-length=MM --build=aarch64-unknown-linux-gnu \
- && make && make check && make install
+ && wget https://hepmc.web.cern.ch/hepmc/releases/HepMC-2.06.11.tar.gz \
+ && tar -zxf HepMC-2.06.11.tar.gz \
+ && mkdir HepMC_build && cd HepMC_build \
+ && cmake -DCMAKE_INSTALL_PREFIX=/usr/local -Dmomentum=GEV -Dlength=MM ../HepMC-2.06.11 \
+ && make && make test && make install
 
-RUN pip install --upgrade setuptools \
- && pip install six \
- && ln -fs /usr/bin/python2.7 /usr/bin/python \
- && ln -fs /usr/bin/pip2.7 /usr/bin/pip
-
+# Clean up
 RUN rm -rf /tmp/*
 
-RUN yum install sudo -y \
- && sudo localedef -c -f UTF-8 -i en_US en_US.UTF-8
-
-RUN useradd atreus \
- && usermod -aG wheel atreus \
- && echo "%wheel  ALL=(ALL)       NOPASSWD: ALL" | tee -a /etc/sudoers 
-
-RUN ln -fs /usr/local/bin/python3.9 /usr/bin/python
-
-USER atreus
-
-ENV HOME=/home/atreus
-RUN chmod 777 /home/atreus \
- && ln -fs /mnt /home/atreus/data
-
-WORKDIR /home/atreus
+USER root

--- a/madlad/container/build.py
+++ b/madlad/container/build.py
@@ -10,11 +10,10 @@ def DockerBuild(config: str):
     with open(config) as f:
         settings = yaml.load(f, Loader=yaml.SafeLoader)
 
-    init = """FROM tzuhanchang/madlad:madlad-base
+    init = """FROM tzuhanchang/madlad:latest
 
     # metainformation
-    LABEL org.opencontainers.image.base.name="docker.io/library/tzuhanchang/madlad:madlad-base"
-
+    LABEL org.opencontainers.image.base.name="docker.io/library/tzuhanchang/madlad:latest"
     """
 
     with open("Dockerfile", "w") as text_file:
@@ -82,7 +81,7 @@ def SingularityBuild(config: str):
     move = f"cp -R {settings['build']['mg5']}" + " ${SINGULARITY_ROOTFS}/home/atreus/MG5_aMC" if external_mg5 is False else ""
 
     init = f"""Bootstrap: docker
-From: tzuhanchang/madlad:madlad-base
+From: tzuhanchang/madlad:latest
 
 %setup
     {move}
@@ -139,7 +138,7 @@ From: tzuhanchang/madlad:madlad-base
             warnings.warn("No optional models provided, none will be downloaded.")
             pass
 
-        text_file.write("    sudo rm -rf /home/atreus/singularity-build")
+        text_file.write("    rm -rf /home/atreus/singularity-build")
 
     try:
         image_name = settings['image']['name']

--- a/madlad/container/commands.py
+++ b/madlad/container/commands.py
@@ -12,7 +12,7 @@ def fastjet_build(version: str) -> Tuple[str,str]:
  && wget {download_link} \\
  && tar -zxf fastjet-{version}.tar.gz \\
  && cd fastjet-{version} && ./configure --prefix=/usr/local \\
- && sudo make && sudo make check && sudo make install
+ && make && make check && make install
 
 """
 
@@ -20,7 +20,7 @@ def fastjet_build(version: str) -> Tuple[str,str]:
     wget {download_link}
     tar -zxf fastjet-{version}.tar.gz
     cd fastjet-3.4.0 && ./configure --prefix=/usr/local
-    sudo make && sudo make check && sudo make install
+    make && make check && make install
 
 """
     return docker_command, singularity_command
@@ -36,14 +36,14 @@ def delphes_build(version: str) -> Tuple[str,str]:
     docker_command = f"""RUN cd /tmp \\
  && wget {download_link} \\
  && tar -zxf Delphes-{version}.tar.gz && mkdir Delphes_build && cd Delphes_build \\
- && cmake ../Delphes-{version} && sudo make install
+ && cmake ../Delphes-{version} && make install
 
 """
 
     singularity_command = f"""    cd /home/atreus/singularity-build
     wget {download_link}
     tar -zxf Delphes-{version}.tar.gz && mkdir Delphes_build && cd Delphes_build
-    cmake ../Delphes-{version} && sudo make install
+    cmake ../Delphes-{version} && make install
 
 """
     return docker_command, singularity_command
@@ -58,16 +58,16 @@ def lhapdf_build(version: str) -> Tuple[str,str]:
     docker_command = f"""RUN cd /tmp \\
  && wget {download_link} -O LHAPDF-{version}.tar.gz \\
  && tar -zxf LHAPDF-{version}.tar.gz && cd LHAPDF-{version} \\
- && ./configure LIBS="-L/usr/local/lib/python3.9" --prefix=/usr/local \\
- && sudo make && sudo make install
+ && ./configure --prefix=/usr/local \\
+ && make && make install
 
 """
 
     singularity_command = f"""    cd /home/atreus/singularity-build
     wget {download_link} -O LHAPDF-{version}.tar.gz
     tar -zxf LHAPDF-{version}.tar.gz && cd LHAPDF-{version}
-    ./configure LIBS="-L/usr/local/lib/python3.9" --prefix=/usr/local
-    sudo make && sudo make install
+    ./configure --prefix=/usr/local
+    make && make install
 
 """
     return docker_command, singularity_command
@@ -87,14 +87,14 @@ def pythia8_build(version: str) -> Tuple[str,str]:
  && wget {download_link} \\
  && tar -xf pythia8{release}.tar && cd pythia8{release} \\
  && ./configure --prefix=/usr/local --with-hepmc2=/usr/local --with-hepmc2-include=/usr/local/include --with-lhapdf6=/usr/local --with-lhapdf6-plugin=LHAPDF6.h --with-gzip=/usr\\
- && sudo make && sudo make install
+ && make && make install
 
 """
     singularity_command = f"""    cd /home/atreus/singularity-build
     wget {download_link}
     tar -xf pythia8{release}.tar && cd pythia8{release}
     ./configure --prefix=/usr/local --with-hepmc2=/usr/local --with-hepmc2-include=/usr/local/include --with-lhapdf6=/usr/local --with-lhapdf6-plugin=LHAPDF6.h --with-gzip=/usr
-    sudo make && sudo make install
+    make && make install
 
 """
     return docker_command, singularity_command
@@ -113,53 +113,53 @@ def mg5_build(version: Optional[str] = None, external: Optional[str] = None) -> 
             download_link = f"https://launchpad.net/mg5amcnlo/lts/{release}/+download/MG5_aMC_v{version}.tar.gz"
         file_name = download_link.split("/")[-1]
 
-        docker_command = f"""RUN sudo mkdir /app && cd /app && sudo mkdir MG5_aMC \\
- && sudo wget {download_link} \\
- && sudo tar -zxf {file_name} -C MG5_aMC --strip-components 1 && cd MG5_aMC \\
- && sudo ln -fs /app/MG5_aMC/bin/mg5_aMC /usr/local/bin/mg5 \\
- && sudo sed -i 's/# pythia8_path = .\/HEPTools\/pythia8/pythia8_path = \/usr\/local/' ./input/mg5_configuration.txt \\
- && sudo sed -i 's/# delphes_path = .\/Delphes/delphes_path = \/usr\/local/' ./input/mg5_configuration.txt \\
- && sudo sed -i 's/# lhapdf_py3 = lhapdf-config/lhapdf_py3 = \/usr\/local\/bin\/lhapdf-config/' ./input/mg5_configuration.txt \\
- && sudo sed -i 's/# fastjet = fastjet-config/fastjet = \/usr\/local\/bin\/fastjet-config/' ./input/mg5_configuration.txt \\
+        docker_command = f"""RUN mkdir /app && cd /app && mkdir MG5_aMC \\
+ && wget {download_link} \\
+ && tar -zxf {file_name} -C MG5_aMC --strip-components 1 && cd MG5_aMC \\
+ && ln -fs /app/MG5_aMC/bin/mg5_aMC /usr/local/bin/mg5 \\
+ && sed -i 's/# pythia8_path = .\/HEPTools\/pythia8/pythia8_path = \/usr\/local/' ./input/mg5_configuration.txt \\
+ && sed -i 's/# delphes_path = .\/Delphes/delphes_path = \/usr\/local/' ./input/mg5_configuration.txt \\
+ && sed -i 's/# lhapdf_py3 = lhapdf-config/lhapdf_py3 = \/usr\/local\/bin\/lhapdf-config/' ./input/mg5_configuration.txt \\
+ && sed -i 's/# fastjet = fastjet-config/fastjet = \/usr\/local\/bin\/fastjet-config/' ./input/mg5_configuration.txt \\
  && cd /tmp && echo -e "import model loop_sm-no_b_mass\\ninstall mg5amc_py8_interface\\ngenerate p p > t t~ [QCD]\\noutput mg5_test_run" > mg5_exec_card \\
- && sudo /usr/local/bin/mg5 mg5_exec_card && cd /
+ && /usr/local/bin/mg5 mg5_exec_card && cd /
 
 """
-        singularity_command = f"""    sudo mkdir /app && cd /home/atreus/singularity-build && mkdir MG5_aMC
+        singularity_command = f"""    mkdir /app && cd /home/atreus/singularity-build && mkdir MG5_aMC
     wget {download_link}
     tar -zxf {file_name} -C MG5_aMC --strip-components 1
     mv MG5_aMC /app/MG5_aMC && cd /app/MG5_aMC
-    sudo ln -fs /app/MG5_aMC/bin/mg5_aMC /usr/local/bin/mg5
-    sudo sed -i 's/# pythia8_path = .\/HEPTools\/pythia8/pythia8_path = \/usr\/local/' ./input/mg5_configuration.txt
-    sudo sed -i 's/# delphes_path = .\/Delphes/delphes_path = \/usr\/local/' ./input/mg5_configuration.txt
-    sudo sed -i 's/# lhapdf_py3 = lhapdf-config/lhapdf_py3 = \/usr\/local\/bin\/lhapdf-config/' ./input/mg5_configuration.txt
-    sudo sed -i 's/# fastjet = fastjet-config/fastjet = \/usr\/local\/bin\/fastjet-config/' ./input/mg5_configuration.txt
+    ln -fs /app/MG5_aMC/bin/mg5_aMC /usr/local/bin/mg5
+    sed -i 's/# pythia8_path = .\/HEPTools\/pythia8/pythia8_path = \/usr\/local/' ./input/mg5_configuration.txt
+    sed -i 's/# delphes_path = .\/Delphes/delphes_path = \/usr\/local/' ./input/mg5_configuration.txt
+    sed -i 's/# lhapdf_py3 = lhapdf-config/lhapdf_py3 = \/usr\/local\/bin\/lhapdf-config/' ./input/mg5_configuration.txt
+    sed -i 's/# fastjet = fastjet-config/fastjet = \/usr\/local\/bin\/fastjet-config/' ./input/mg5_configuration.txt
     cd /home/atreus/singularity-build && echo -e "import model loop_sm-no_b_mass\\ninstall mg5amc_py8_interface\\ngenerate p p > t t~ [QCD]\\noutput mg5_test_run" > mg5_exec_card
-    sudo /usr/local/bin/mg5 mg5_exec_card && cd /
+    /usr/local/bin/mg5 mg5_exec_card && cd /
 
 """
 
     if external is not None:
-        docker_command = f"""RUN sudo mkdir -p /app/MG5_aMC
+        docker_command = f"""RUN mkdir -p /app/MG5_aMC
 COPY {external} /app/MG5_aMC
 RUN cd /app/MG5_aMC \\
- && sudo ln -fs /app/MG5_aMC/bin/mg5_aMC /usr/local/bin/mg5 \\
- && sudo sed -i 's/# pythia8_path = .\/HEPTools\/pythia8/pythia8_path = \/usr\/local/' ./input/mg5_configuration.txt \\
- && sudo sed -i 's/# delphes_path = .\/Delphes/delphes_path = \/usr\/local/' ./input/mg5_configuration.txt \\
- && sudo sed -i 's/# lhapdf_py3 = lhapdf-config/lhapdf_py3 = \/usr\/local\/bin\/lhapdf-config/' ./input/mg5_configuration.txt \\
- && sudo sed -i 's/# fastjet = fastjet-config/fastjet = \/usr\/local\/bin\/fastjet-config/' ./input/mg5_configuration.txt \\
+ && ln -fs /app/MG5_aMC/bin/mg5_aMC /usr/local/bin/mg5 \\
+ && sed -i 's/# pythia8_path = .\/HEPTools\/pythia8/pythia8_path = \/usr\/local/' ./input/mg5_configuration.txt \\
+ && sed -i 's/# delphes_path = .\/Delphes/delphes_path = \/usr\/local/' ./input/mg5_configuration.txt \\
+ && sed -i 's/# lhapdf_py3 = lhapdf-config/lhapdf_py3 = \/usr\/local\/bin\/lhapdf-config/' ./input/mg5_configuration.txt \\
+ && sed -i 's/# fastjet = fastjet-config/fastjet = \/usr\/local\/bin\/fastjet-config/' ./input/mg5_configuration.txt \\
  && cd /tmp && echo -e "import model loop_sm-no_b_mass\\ninstall mg5amc_py8_interface\\ngenerate p p > t t~ [QCD]\\noutput mg5_test_run" > mg5_exec_card \\
- && sudo /usr/local/bin/mg5 mg5_exec_card && cd /
+ && /usr/local/bin/mg5 mg5_exec_card && cd /
 
 """
-        singularity_command = f"""    sudo mkdir /app && sudo mv /home/atreus/MG5_aMC /app/ && cd /app/MG5_aMC
-    sudo ln -fs /app/MG5_aMC/bin/mg5_aMC /usr/local/bin/mg5
-    sudo sed -i 's/# pythia8_path = .\/HEPTools\/pythia8/pythia8_path = \/usr\/local/' ./input/mg5_configuration.txt
-    sudo sed -i 's/# delphes_path = .\/Delphes/delphes_path = \/usr\/local/' ./input/mg5_configuration.txt
-    sudo sed -i 's/# lhapdf_py3 = lhapdf-config/lhapdf_py3 = \/usr\/local\/bin\/lhapdf-config/' ./input/mg5_configuration.txt
-    sudo sed -i 's/# fastjet = fastjet-config/fastjet = \/usr\/local\/bin\/fastjet-config/' ./input/mg5_configuration.txt
+        singularity_command = f"""    mkdir /app && mv /home/atreus/MG5_aMC /app/ && cd /app/MG5_aMC
+    ln -fs /app/MG5_aMC/bin/mg5_aMC /usr/local/bin/mg5
+    sed -i 's/# pythia8_path = .\/HEPTools\/pythia8/pythia8_path = \/usr\/local/' ./input/mg5_configuration.txt
+    sed -i 's/# delphes_path = .\/Delphes/delphes_path = \/usr\/local/' ./input/mg5_configuration.txt
+    sed -i 's/# lhapdf_py3 = lhapdf-config/lhapdf_py3 = \/usr\/local\/bin\/lhapdf-config/' ./input/mg5_configuration.txt
+    sed -i 's/# fastjet = fastjet-config/fastjet = \/usr\/local\/bin\/fastjet-config/' ./input/mg5_configuration.txt
     cd /home/atreus/singularity-build && echo -e "import model loop_sm-no_b_mass\\ninstall mg5amc_py8_interface\\ngenerate p p > t t~ [QCD]\\noutput mg5_test_run" > mg5_exec_card
-    sudo /usr/local/bin/mg5 mg5_exec_card && cd /
+    /usr/local/bin/mg5 mg5_exec_card && cd /
 
 """
 

--- a/madlad/container/download.py
+++ b/madlad/container/download.py
@@ -38,12 +38,12 @@ def get_model(model_names: List|str, model_dict: str = "/app/MG5_aMC/models", bu
                 if build_method == "docker":
                     to_write += [
                         "cd %s"%(model_dict),
-                        "sudo wget %s"%(lookup_dict[key]),
-                        "sudo %s %s"%(extract_command, file_name),
+                        "wget %s"%(lookup_dict[key]),
+                        "%s %s"%(extract_command, file_name),
                         "cd /tmp",
-                        "sudo echo -e \"convert model %s/%s\" > convert.dat"%(model_dict, main_model_name),
-                        "sudo /usr/local/bin/mg5 convert.dat",
-                        "sudo rm convert.dat"
+                        "echo -e \"convert model %s/%s\" > convert.dat"%(model_dict, main_model_name),
+                        "/usr/local/bin/mg5 convert.dat",
+                        "rm convert.dat"
                     ]
                 elif build_method == "singularity":
                     to_write += [
@@ -98,7 +98,7 @@ def get_pdfset(pdf_ids: List|int, pdfsets_dict: Optional[str] = "/usr/local/shar
         if is_int:
             try:
                 if build_method == "docker":
-                    pdf_links = "sudo wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/%s.tar.gz && sudo tar -zxf %s.tar.gz"%(all_pdfs[str(pdf_ids)],all_pdfs[str(pdf_ids)])
+                    pdf_links = "wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/%s.tar.gz && tar -zxf %s.tar.gz"%(all_pdfs[str(pdf_ids)],all_pdfs[str(pdf_ids)])
                 elif build_method == "singularity":
                     pdf_links = "wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/%s.tar.gz && tar -zxf %s.tar.gz"%(all_pdfs[str(pdf_ids)],all_pdfs[str(pdf_ids)])
             except KeyError:
@@ -106,7 +106,7 @@ def get_pdfset(pdf_ids: List|int, pdfsets_dict: Optional[str] = "/usr/local/shar
         else:
             try:
                 if build_method == "docker":
-                    pdf_links = [ "sudo wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/%s.tar.gz && sudo tar -zxf %s.tar.gz"%(all_pdfs[str(pdf_id)],all_pdfs[str(pdf_id)]) for pdf_id in pdf_ids ]
+                    pdf_links = [ "wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/%s.tar.gz && tar -zxf %s.tar.gz"%(all_pdfs[str(pdf_id)],all_pdfs[str(pdf_id)]) for pdf_id in pdf_ids ]
                 elif build_method == "singularity":
                     pdf_links = [ "wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/%s.tar.gz && tar -zxf %s.tar.gz"%(all_pdfs[str(pdf_id)],all_pdfs[str(pdf_id)]) for pdf_id in pdf_ids ]
             except KeyError:

--- a/madlad/controls/delphes.py
+++ b/madlad/controls/delphes.py
@@ -30,8 +30,8 @@ def runDelphes(cfg : DictConfig, dir: str, run_with: str, image_name: str, logge
             logger.info('Running post commands using Docker.')
             subprocess.run(
                 [
-                    "docker", "run", "--rm", "-it", "-w", "/home/atreus/data",
-                    "-v", f"{Path().absolute()}:/home/atreus/data",
+                    "docker", "run", "--rm", "-it", "-w", "/root",
+                    "-v", f"{Path().absolute()}:/root",
                     image_name, "/bin/bash", f"delphes_exec_card-{os.path.basename(dir)}"
                 ]
             )

--- a/madlad/controls/exec.py
+++ b/madlad/controls/exec.py
@@ -24,8 +24,8 @@ def makeProcess(cfg : DictConfig, logger) -> None:
         logger.info('Creating a MG5 run directory with Docker.')
         subprocess.run(
             [
-                "docker", "run", "--rm", "-it", "-w", "/home/atreus/data",
-                "-v", f"{Path().absolute()}:/home/atreus/data",
+                "docker", "run", "--rm", "-it", "-w", "/root",
+                "-v", f"{Path().absolute()}:/root",
                 image_name, cfg['run']['mg5'],
                 f"proc_card_mg5-{os.path.basename(cfg['gen']['block_model']['save_dir'])}.dat"
             ]

--- a/madlad/controls/launch.py
+++ b/madlad/controls/launch.py
@@ -32,8 +32,8 @@ def launchEvtGen(cfg : DictConfig, dir: str, logger) -> None:
         logger.info('Running MG5 event generation using Docker.')
         subprocess.run(
             [
-                "docker", "run", "--rm", "-it", "-w", "/home/atreus/data",
-                "-v", f"{Path().absolute()}:/home/atreus/data",
+                "docker", "run", "--rm", "-it", "-w", "/root",
+                "-v", f"{Path().absolute()}:/root",
                 image_name, cfg['run']['mg5'],
                 f"mg5_exec_card-{os.path.basename(dir)}"
             ]

--- a/madlad/controls/post.py
+++ b/madlad/controls/post.py
@@ -24,8 +24,8 @@ def runPost(cfg : DictConfig, logger) -> None:
             logger.info('Running post commands using Docker.')
             subprocess.run(
                 [
-                    "docker", "run", "--rm", "-it", "-w", "/home/atreus/data",
-                    "-v", f"{Path().absolute()}:/home/atreus/data",
+                    "docker", "run", "--rm", "-it", "-w", "/root",
+                    "-v", f"{Path().absolute()}:/root",
                     image_name, "/bin/bash", f"post-commands"
                 ]
             )


### PR DESCRIPTION
This pull request changes MadLAD base docker image to use [Ubuntu:20.04](https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/oci/index.json?h=refs/tags/dist-focal-amd64-20241011-2dc0aae1&id=2dc0aae17c912aa6ae81e4c4bbc7277692d67bae). This resolves Python issues reported in #62.

Close #62 after merging.