### PR TITLE
Add MadGraph5 configuration

### DIFF
--- a/madlad/controls/launch.py
+++ b/madlad/controls/launch.py
@@ -14,6 +14,9 @@ def launchEvtGen(cfg : DictConfig, dir: str, logger) -> None:
     image_name, run_with = checkImage(cfg, logger)
 
     ecard = open(f"mg5_exec_card-{os.path.basename(dir)}","w")
+    if 'block_settings' in cfg['gen'].keys():
+        for name, val in cfg['gen']['block_settings'].items():
+            ecard.write(f"set {name} {val}\n")
     if cfg['run']['shower'] is False:
         logger.info('Writing Gen card, without parton shower.')
         if cfg['gen']['block_model']['order'].lower() == "lo":

--- a/madlad/parameters/process.py
+++ b/madlad/parameters/process.py
@@ -12,6 +12,11 @@ def make_process(cfg : DictConfig) -> None:
     save_dir = cfg['gen']['block_model']['save_dir']
     settings = cfg['gen']['block_model']
 
+    run_settings = ""
+    if 'block_settings' in cfg['gen'].keys():
+        for name, val in cfg['gen']['block_settings'].items():
+            run_settings += f"set {name} {val}"
+
     try:
         model = "import model " + settings['model']
     except KeyError:
@@ -35,7 +40,9 @@ def make_process(cfg : DictConfig) -> None:
 %s
 %s
 %s
+%s
 """%(
+    run_settings,
     model,
     multiparticle,
     proc,

--- a/processes/4top.yaml
+++ b/processes/4top.yaml
@@ -6,6 +6,10 @@ run:
   shower:      True
 
 gen:
+  block_settings:
+    run_mode:       2
+    nb_core:        4
+
   block_model:
     model:          loop_sm-no_b_mass
     multiparticle:  ["p = g u c d s b u~ c~ d~ s~ b~", "j = g u c d s b u~ c~ d~ s~ b~"]

--- a/processes/ttbar-allhad.yaml
+++ b/processes/ttbar-allhad.yaml
@@ -6,6 +6,10 @@ run:
   shower:      True
 
 gen:
+  block_settings:
+    run_mode:       2
+    nb_core:        4
+
   block_model:
     model:          loop_sm-no_b_mass
     multiparticle:  ["p = g u c d s u~ c~ d~ s~ b b~", "j = g u c d s u~ c~ d~ s~ b b~"]


### PR DESCRIPTION
This pull request adds options to overwrite the MadGraph configurations found in `MG5_aMC_v*/input/mg5_configuration.txt`.

Example:
```yaml
...
  gen:
    block_settings:
      nb_core:        4
      ...
...
```
This overwrites the default number of cores MadGraph will use to compile or set up clusters.