### PR TITLE
Fix missing line break while passing `gen.run_settings`

### DIFF
--- a/madlad/parameters/process.py
+++ b/madlad/parameters/process.py
@@ -15,7 +15,7 @@ def make_process(cfg : DictConfig) -> None:
     run_settings = ""
     if 'block_settings' in cfg['gen'].keys():
         for name, val in cfg['gen']['block_settings'].items():
-            run_settings += f"set {name} {val}"
+            run_settings += f"set {name} {val}\n"
 
     try:
         model = "import model " + settings['model']


### PR DESCRIPTION
During the MadGraph process creation, `gen.run_settings` are not correctly passed due to missing line breaks. This pull request fixes this issue.