### PR TITLE
Fix `ssWWjj_nlo-vlvl` MadSpin card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+ - Fix `ssWWjj_nlo-vlvl` MadSpin card ([#85](https://github.com/tzuhanchang/MadLAD/pull/85))
  - Fix Python 2 model conversion issue ([#84](https://github.com/tzuhanchang/MadLAD/pull/84))
  - Fix Singularity build with an external MG5 directory ([#70](https://github.com/tzuhanchang/MadLAD/pull/70))
 

--- a/processes/ssWWjj_nlo-vlvl.yaml
+++ b/processes/ssWWjj_nlo-vlvl.yaml
@@ -50,7 +50,7 @@ gen:
 
   block_madspin:
     misc:
-      - import ${gen.block_model.save_dir}/Events/run_01
+      - import ${gen.block_model.save_dir}/Events/run_01/events.lhe
       - set ms_dir ${gen.block_model.save_dir}/Events/run_01_decayed
     multiparticle:
       - l+ = e+ mu+


### PR DESCRIPTION
The `events.lhe` has to be specified instead of the run path. This pull request fixed this issue.