### PR TITLE
Upgrade base image Ubuntu version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add Shower Controls ([#61](https://github.com/tzuhanchang/MadLAD/pull/61))
 
 ### Changed
+ - Upgrade base image Ubuntu version ([#86](https://github.com/tzuhanchang/MadLAD/pull/86))
  - Bump up example MG5 version and add more models and PDF sets g ([#83](https://github.com/tzuhanchang/MadLAD/pull/83))
  - Use GitHub Page for documentation hosting ([#72](https://github.com/tzuhanchang/MadLAD/pull/72))
  - Use MkDocs Material for documentation ([#71](https://github.com/tzuhanchang/MadLAD/pull/71))

--- a/madlad/container/Dockerfile
+++ b/madlad/container/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:focal
+FROM ubuntu:noble
 
 # metainformation
-LABEL org.opencontainers.image.version="4.0.0"
+LABEL org.opencontainers.image.version="5.0.0"
 LABEL org.opencontainers.image.authors="Zihan Zhang"
 LABEL org.opencontainers.image.source="https://zhangzi.web.cern.ch"
 


### PR DESCRIPTION
Base container image has been upgraded from `ubuntu:focal` to `ubuntu:noble`.